### PR TITLE
Handle application and communication resets

### DIFF
--- a/MAX32xxx/CO_driver_max32xxx.c
+++ b/MAX32xxx/CO_driver_max32xxx.c
@@ -152,16 +152,21 @@ CO_ReturnError_t CO_CANmodule_init(
 
 
     /* Configure CAN module registers */
+    if (MXC_CAN_PowerControl(MXC_CAN_GET_IDX(CANmodule->CANptr),
+        MXC_CAN_PWR_CTRL_FULL) != E_NO_ERROR) {
+        PRINT("%s: Error: MXC_CAN_PowerControl() failed\n", __func__);
+        return CO_ERROR_INVALID_STATE;
+    }
 #if TARGET_NUM == 32662
     if (MXC_CAN_Init(MXC_CAN_GET_IDX(CANmodule->CANptr), MXC_CAN_OBJ_CFG_TXRX,
             canUnitEvent_cb, canObjEvent_cb, MAP_B) != E_NO_ERROR) {
-        return CO_ERROR_ILLEGAL_ARGUMENT;
+        return CO_ERROR_INVALID_STATE;
     }
 #elif TARGET_NUM == 32690
     if (MXC_CAN_Init(MXC_CAN_GET_IDX(CANmodule->CANptr),
             MXC_CAN_OBJ_CFG_TXRX, canUnitEvent_cb,
             canObjEvent_cb) != E_NO_ERROR) {
-        return CO_ERROR_ILLEGAL_ARGUMENT;
+        return CO_ERROR_INVALID_STATE;
     }
 #endif
 
@@ -197,7 +202,10 @@ CO_ReturnError_t CO_CANmodule_init(
         /* CAN module filters are not used, all messages with standard 11-bit */
         /* identifier will be received */
         /* Configure mask 0 so, that all messages with standard identifier are accepted */
-        MXC_CAN_ObjectSetFilter(MXC_CAN_GET_IDX(CANmodule->CANptr),
+    	MXC_CAN_ObjectSetFilter(MXC_CAN_GET_IDX(CANmodule->CANptr),
+		MXC_CAN_FILT_CFG_MASK_DEL | MXC_CAN_FILT_CFG_SINGLE_STD_ID,
+		CAN_STD_ID_MASK, 0);
+    	MXC_CAN_ObjectSetFilter(MXC_CAN_GET_IDX(CANmodule->CANptr),
                 MXC_CAN_FILT_CFG_MASK_ADD | MXC_CAN_FILT_CFG_SINGLE_STD_ID,
                 CAN_STD_ID_MASK, 0);
     }

--- a/MAX32xxx/CO_driver_target.h
+++ b/MAX32xxx/CO_driver_target.h
@@ -41,6 +41,17 @@
 /* Disable storage */
 #define CO_CONFIG_STORAGE	0x00
 
+#ifndef CO_CONFIG_SDO_SRV
+#define CO_CONFIG_SDO_SRV (CO_CONFIG_SDO_SRV_SEGMENTED | \
+                           CO_CONFIG_SDO_SRV_BLOCK)
+#endif
+#ifndef CO_CONFIG_SDO_SRV_BUFFER_SIZE
+#define CO_CONFIG_SDO_SRV_BUFFER_SIZE 900
+#endif
+#ifndef CO_CONFIG_CRC16
+#define CO_CONFIG_CRC16 (CO_CONFIG_CRC16_ENABLE)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/MAX32xxx/CO_main_max32xxx.c
+++ b/MAX32xxx/CO_main_max32xxx.c
@@ -77,7 +77,7 @@ int main (void){
     void *CANptr = NULL; /* CAN module address */
     uint8_t pendingNodeId = 0; /* read from dip switches or nonvolatile memory, configurable by LSS slave */
     uint8_t activeNodeId = 0; /* Copied from CO_pendingNodeId in the communication reset section */
-    uint16_t pendingBitRate = 125;  /* read from dip switches or nonvolatile memory, configurable by LSS slave */
+    uint16_t pendingBitRate = 0;  /* read from dip switches or nonvolatile memory, configurable by LSS slave */
 
 #if (CO_CONFIG_STORAGE) & CO_CONFIG_STORAGE_ENABLE
     CO_storage_t storage;


### PR DESCRIPTION
Support CO_RESET_APP and CO_RESET_COMM so that the tests succeed.

During communication reset, remove CAN filter before adding it again as the underlying driver keeps track of the number of filters used at any given time.

Finally, enable SDO block transfers as it is also part of the tests.